### PR TITLE
Ensure target index is correctly detected

### DIFF
--- a/a11y-accordion-tabs.js
+++ b/a11y-accordion-tabs.js
@@ -149,7 +149,7 @@
       this.isAccordion = false;
     }
 
-    var targetIndex = e.target.index != null ? e.target.index : closestTab.index;
+    var targetIndex = e.target.index != null ? e.target.index : closestTab.index != null ? closestTab.index : closestTrigger.index;
 
     if (targetIndex === this.selectedTab && !this.isAccordion) {
       return;


### PR DESCRIPTION
If html tags are included in the tab titles, it breaks depending on exact click location. this resolves that.